### PR TITLE
#11 add aws terraform provider, create s3 bucket

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.17.0"
+  constraints = "5.17.0"
+  hashes = [
+    "h1:U+EDfeUqefebA1h7KyBMD1xH0h311LMi7wijPDPkC/0=",
+    "zh:0087b9dd2c9c638fd63e527e5b9b70988008e263d480a199f180efe5a4f070f0",
+    "zh:0fd532a4fd03ddef11f0502ff9fe4343443e1ae805cb088825a71d6d48906ec7",
+    "zh:16411e731100cd15f7e165f53c23be784b2c86c2fcfd34781e0642d17090d342",
+    "zh:251d520927e77f091e2ec6302e921d839a2430ac541c6a461aed7c08fb5eae12",
+    "zh:4919e69682dc2a8c32d44f6ebc038a52c9f40af9c61cb574b64e322800d6a794",
+    "zh:5334c60759d5f76bdc51355d1a3ebcc451d4d20f632f5c73b6e55c52b5dc9e52",
+    "zh:7341a2b7247572eba0d0486094a870b872967702ec0ac7af728c2df2c30af4e5",
+    "zh:81d1b1cb2cac6b3922a05adab69543b678f344a01debd54500263700dad7a288",
+    "zh:882bc8e15ef6d4020a07321ec4c056977c5c1d96934118032922561d29504d43",
+    "zh:8cd4871ef2b03fd916de1a6dc7eb8a81a354c421177d4334a2e3308e50215e41",
+    "zh:97e12fe6529b21298adf1046c5e20ac35d0569c836a6f385ff041e257e00cfd2",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f5baf5d59b9f3cf5504d1fa975f10f27da3791896a9e18ece47c258bac17634",
+    "zh:dffafba6731ac1db1c540bdbd6a8c878486b71de9d0ca1d23c5c00a6c3c14d80",
+    "zh:fa7440c3c15a42fc5731444d324ced75407d417bfe3184661ae47d40a9718dce",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = "3.5.1"

--- a/README.md
+++ b/README.md
@@ -237,3 +237,13 @@ provider "random" {
 ### Terraform Directory
 
 `.terraform` directory contains binaries of providers.
+
+### Terraform Destroy
+
+`teraform destroy` will destroy resources that terraform knows about.
+
+- Use `--auto-approve` to skip manually approving a plan or destroy
+
+```
+terraform apply --auto-approve
+```

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/random"
       version = "3.5.1"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.17.0"
+    }
   }
 }
 
@@ -11,9 +15,23 @@ provider "random" {
   # Configuration options
 }
 
+provider "aws" {
+  # Configuration options
+}
+
+# https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string
 resource "random_string" "bucket_name" {
-  length  = 16
+  length  = 32
   special = false
+  lower = true
+  upper = false
+}
+
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
+resource "aws_s3_bucket" "example" {
+  # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+  bucket = random_string.bucket_name.result
+
 }
 
 output "random_bucket_name" {


### PR DESCRIPTION
S3 bucket names are used globally. So naming the buckets properly is important. So important that AWS has  bucket naming rules
https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html.